### PR TITLE
set readthedocs to use python 3.10

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.10"
   jobs:
     post_install:
       - pip install uv


### PR DESCRIPTION
Configure readthedocs to use python3.10

## Motivation
Building with python 3.13 is not supported

## Modification

The python version in .readthedocs.yaml is changed from 3.13 to 3.10

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
