### PR TITLE
fix: only accept boolean for bgr_to_rgb inputs

### DIFF
--- a/mmengine/model/base_model/data_preprocessor.py
+++ b/mmengine/model/base_model/data_preprocessor.py
@@ -212,6 +212,12 @@ class ImgDataPreprocessor(BaseDataPreprocessor):
                  rgb_to_bgr: bool = False,
                  non_blocking: Optional[bool] = False):
         super().__init__(non_blocking)
+        if not isinstance(bgr_to_rgb, bool):
+            raise TypeError(f'`bgr_to_rgb` should be a boolean, but got '
+                            f'{type(bgr_to_rgb)}')
+        if not isinstance(rgb_to_bgr, bool):
+            raise TypeError(f'`rgb_to_bgr` should be a boolean, but got '
+                            f'{type(rgb_to_bgr)}')
         assert not (bgr_to_rgb and rgb_to_bgr), (
             '`bgr2rgb` and `rgb2bgr` cannot be set to True at the same time')
         assert (mean is None) == (std is None), (

--- a/tests/test_model/test_base_model/test_data_preprocessor.py
+++ b/tests/test_model/test_base_model/test_data_preprocessor.py
@@ -118,6 +118,14 @@ class TestImgDataPreprocessor(TestBaseDataPreprocessor):
         with self.assertRaisesRegex(AssertionError, '`std` should have'):
             ImgDataPreprocessor(mean=(1, 2, 3), std=(1, 2))
 
+        with self.assertRaisesRegex(TypeError,
+                                    '`bgr_to_rgb` should be a boolean'):
+            ImgDataPreprocessor(bgr_to_rgb='false')
+
+        with self.assertRaisesRegex(TypeError,
+                                    '`rgb_to_bgr` should be a boolean'):
+            ImgDataPreprocessor(rgb_to_bgr=1)
+
         with self.assertRaisesRegex(AssertionError, '`bgr2rgb` and `rgb2bgr`'):
             ImgDataPreprocessor(bgr_to_rgb=True, rgb_to_bgr=True)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OneDL-MMengine](https://onedl-mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation
Sometimes people set bgr_to_rgb to 'false' in their config (as a string). This translates to True and is thus not what they intend. This MR will raise an error if a string is passed to prevent this.

## Modification

ImgDataPreprocessor.

## BC-breaking (Optional)
It will affect every DataProcessor inheriting from ImgDataPreprocessor.  However, it should not break anything because default configs use booleans and it will flag unintended use.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.
