### PR TITLE
perf(runner): speed up --resume with a multi-worker-safe sampler skip

### DIFF
--- a/mmengine/dataset/sampler.py
+++ b/mmengine/dataset/sampler.py
@@ -156,6 +156,28 @@ class InfiniteSampler(Sampler):
         """Iterate the indices."""
         yield from self.indices
 
+    def skip(self, num_samples: int) -> None:
+        """Fast-forward the sampler to an absolute position for resuming.
+
+        It rebuilds the deterministic index stream from the seed and discards
+        the first ``num_samples`` indices, so the next iteration continues from
+        the same position as an uninterrupted run. ``num_samples`` is absolute
+        (counted from the start of the stream, per rank), not relative to the
+        current position, and this method is meant to be called once before
+        iterating. Only indices are generated and no data is loaded, so it is
+        safe for any ``num_workers``; the cost is ``O(num_samples)`` index
+        generation, which is still far cheaper than loading the skipped data.
+
+        Args:
+            num_samples (int): The number of per-rank indices already consumed
+                in the previous training that should be skipped. Must be a
+                non-negative integer.
+        """
+        assert num_samples >= 0, \
+            f'`num_samples` should be non-negative, but got {num_samples}'
+        self.indices = itertools.islice(self._indices_of_rank(), num_samples,
+                                        None)
+
     def __len__(self) -> int:
         """Length of base dataset."""
         return self.size

--- a/mmengine/dataset/sampler.py
+++ b/mmengine/dataset/sampler.py
@@ -173,8 +173,9 @@ class InfiniteSampler(Sampler):
                 in the previous training that should be skipped. Must be a
                 non-negative integer.
         """
-        assert num_samples >= 0, \
-            f'`num_samples` should be non-negative, but got {num_samples}'
+        if num_samples < 0:
+            raise ValueError(
+                f'`num_samples` should be non-negative, but got {num_samples}')
         self.indices = itertools.islice(self._indices_of_rank(), num_samples,
                                         None)
 

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -5,7 +5,7 @@ import time
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
-from torch.utils.data import DataLoader, IterableDataset
+from torch.utils.data import BatchSampler, DataLoader, IterableDataset
 
 from mmengine.evaluator import Evaluator
 from mmengine.logging import HistoryBuffer, print_log
@@ -176,9 +176,9 @@ class _InfiniteDataloaderIterator:
     def skip_iter(self, num_iters: int) -> None:
         if num_iters <= 0:
             return
-        sampler = getattr(self._dataloader, 'sampler', None)
+        sampler = self._resolve_sampler()
         batch_size = self._resolve_batch_size()
-        if batch_size and sampler is not None and hasattr(sampler, 'skip'):
+        if batch_size and sampler is not None:
             # Fast path (multi-worker safe): advance the deterministic sampler
             # stream by the number of already-consumed indices, then drop the
             # iterator so it is rebuilt lazily on the next ``__next__`` and the
@@ -189,16 +189,31 @@ class _InfiniteDataloaderIterator:
             self._iterator = None
         else:
             print_log(
-                'Fast sampler-level resume is unavailable: the sampler has no '
-                '`skip` method or the batch size could not be resolved (e.g. a '
-                'custom `batch_sampler`). Falling back to advancing the '
-                'dataloader iterator one step at a time, which is slower and, '
-                'with `num_workers > 0`, still loads and discards the skipped '
-                'data.',
+                'Fast sampler-level resume is unavailable: no sampler with a '
+                '`skip` method was found directly or through a standard '
+                '`BatchSampler`, or the batch size could not be resolved. '
+                'Falling back to advancing the dataloader iterator one step at '
+                'a time, which is slower and, with `num_workers > 0`, still '
+                'loads and discards the skipped data.',
                 logger='current',
                 level=logging.WARNING)
             for _ in range(num_iters):
                 self._next_data(skip_loading=True)
+
+    def _resolve_sampler(self) -> Optional[Any]:
+        sampler = getattr(self._dataloader, 'sampler', None)
+        if sampler is not None and hasattr(sampler, 'skip'):
+            return sampler
+
+        batch_sampler = getattr(self._dataloader, 'batch_sampler', None)
+        # Only unwrap PyTorch's fixed-size BatchSampler. Custom batch samplers
+        # may consume sampler indices differently from ``num_iters * batch_size``.
+        if (batch_sampler is not None
+                and batch_sampler.__class__ is BatchSampler):
+            sampler = getattr(batch_sampler, 'sampler', None)
+            if sampler is not None and hasattr(sampler, 'skip'):
+                return sampler
+        return None
 
     def _resolve_batch_size(self) -> Optional[int]:
         batch_size = getattr(self._dataloader, 'batch_size', None)

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -2,10 +2,10 @@
 import bisect
 import logging
 import time
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, IterableDataset
 
 from mmengine.evaluator import Evaluator
 from mmengine.logging import HistoryBuffer, print_log
@@ -156,41 +156,106 @@ class _InfiniteDataloaderIterator:
 
     def __init__(self, dataloader: DataLoader) -> None:
         self._dataloader = dataloader
-        self._iterator = iter(self._dataloader)
+        # The iterator is created lazily so that, when resuming, the sampler
+        # can be fast-forwarded *before* any worker is spawned and prefetches
+        # data. Eagerly creating it here would make `num_workers > 0` load and
+        # discard the skipped data.
+        self._iterator: Any = None
         self._epoch = 0
 
     def __iter__(self):
         return self
 
     def __next__(self) -> Sequence[dict]:
-        try:
-            data = next(self._iterator)
-        except StopIteration:
+        return self._next_data()
+
+    def _ensure_iterator(self) -> None:
+        if self._iterator is None:
+            self._iterator = iter(self._dataloader)
+
+    def skip_iter(self, num_iters: int) -> None:
+        if num_iters <= 0:
+            return
+        sampler = getattr(self._dataloader, 'sampler', None)
+        batch_size = self._resolve_batch_size()
+        if batch_size and sampler is not None and hasattr(sampler, 'skip'):
+            # Fast path (multi-worker safe): advance the deterministic sampler
+            # stream by the number of already-consumed indices, then drop the
+            # iterator so it is rebuilt lazily on the next ``__next__`` and the
+            # workers prefetch from the resumed position without loading the
+            # skipped data. Relies on the ``skip(num_samples)`` contract
+            # documented on ``InfiniteSampler.skip``.
+            sampler.skip(num_iters * batch_size)
+            self._iterator = None
+        else:
             print_log(
-                'Reach the end of the dataloader, it will be '
-                'restarted and continue to iterate. It is '
-                'recommended to use '
-                '`mmengine.dataset.InfiniteSampler` to enable the '
-                'dataloader to iterate infinitely.',
+                'Fast sampler-level resume is unavailable: the sampler has no '
+                '`skip` method or the batch size could not be resolved (e.g. a '
+                'custom `batch_sampler`). Falling back to advancing the '
+                'dataloader iterator one step at a time, which is slower and, '
+                'with `num_workers > 0`, still loads and discards the skipped '
+                'data.',
                 logger='current',
                 level=logging.WARNING)
-            self._epoch += 1
-            if hasattr(self._dataloader, 'sampler') and hasattr(
-                    self._dataloader.sampler, 'set_epoch'):
-                # In case the` _SingleProcessDataLoaderIter` has no sampler,
-                # or data loader uses `SequentialSampler` in Pytorch.
-                self._dataloader.sampler.set_epoch(self._epoch)
+            for _ in range(num_iters):
+                self._next_data(skip_loading=True)
 
-            elif hasattr(self._dataloader, 'batch_sampler') and hasattr(
-                    self._dataloader.batch_sampler.sampler, 'set_epoch'):
-                # In case the` _SingleProcessDataLoaderIter` has no batch
-                # sampler. batch sampler in pytorch warps the sampler as its
-                # attributes.
-                self._dataloader.batch_sampler.sampler.set_epoch(self._epoch)
-            time.sleep(2)  # Prevent possible deadlock during epoch transition
-            self._iterator = iter(self._dataloader)
-            data = next(self._iterator)
-        return data
+    def _resolve_batch_size(self) -> Optional[int]:
+        batch_size = getattr(self._dataloader, 'batch_size', None)
+        if batch_size is not None:
+            return batch_size
+        # ``batch_size`` is None when a custom ``batch_sampler`` is used; only a
+        # standard fixed-size batch sampler exposes a usable ``batch_size``.
+        batch_sampler = getattr(self._dataloader, 'batch_sampler', None)
+        return getattr(batch_sampler, 'batch_size', None)
+
+    def _next_data(self, skip_loading: bool = False) -> Any:
+        self._ensure_iterator()
+        try:
+            if skip_loading and self._can_skip_without_loading():
+                self._iterator._next_index()
+                return None
+            return next(self._iterator)
+        except StopIteration:
+            self._reset_iterator()
+            if skip_loading and self._can_skip_without_loading():
+                self._iterator._next_index()
+                return None
+            return next(self._iterator)
+
+    def _can_skip_without_loading(self) -> bool:
+        # ``_next_index`` is a private PyTorch API. It only advances the sampler
+        # of a single-process iterator without loading data. For multi-worker
+        # iterators it cannot be used safely (prefetch state would desync), and
+        # it may be absent on future/other iterator types, hence the guards.
+        return (getattr(self._dataloader, 'num_workers', 0) == 0
+                and not isinstance(self._dataloader.dataset, IterableDataset)
+                and hasattr(self._iterator, '_next_index'))
+
+    def _reset_iterator(self) -> None:
+        print_log(
+            'Reach the end of the dataloader, it will be '
+            'restarted and continue to iterate. It is '
+            'recommended to use '
+            '`mmengine.dataset.InfiniteSampler` to enable the '
+            'dataloader to iterate infinitely.',
+            logger='current',
+            level=logging.WARNING)
+        self._epoch += 1
+        if hasattr(self._dataloader, 'sampler') and hasattr(
+                self._dataloader.sampler, 'set_epoch'):
+            # In case the` _SingleProcessDataLoaderIter` has no sampler,
+            # or data loader uses `SequentialSampler` in Pytorch.
+            self._dataloader.sampler.set_epoch(self._epoch)
+
+        elif hasattr(self._dataloader, 'batch_sampler') and hasattr(
+                self._dataloader.batch_sampler.sampler, 'set_epoch'):
+            # In case the` _SingleProcessDataLoaderIter` has no batch
+            # sampler. batch sampler in pytorch warps the sampler as its
+            # attributes.
+            self._dataloader.batch_sampler.sampler.set_epoch(self._epoch)
+        time.sleep(2)  # Prevent possible deadlock during epoch transition
+        self._iterator = iter(self._dataloader)
 
 
 @LOOPS.register_module()
@@ -211,11 +276,15 @@ class IterBasedTrainLoop(BaseLoop):
             corresponding milestone. Defaults to None.
         fast_forward_on_resume (bool): Whether to skip advancing the
             dataloader iterator when resuming from a checkpoint. When
-            `False` (default), the dataloader will iterate through
-            trained steps in the previous training to maintain training
-            state consistency. When `True`, this fast-forward
-            is skipped to save time, but may affect reproducibility if
-            the dataloader has state-dependent behavior.
+            `False` (default), the dataloader is advanced through the
+            already-trained steps to maintain training state consistency.
+            If the sampler supports a `skip` method (e.g.
+            :class:`~mmengine.dataset.InfiniteSampler`) and the batch size
+            can be resolved, this advance is done cheaply at the sampler
+            level without loading the skipped data; otherwise it falls back
+            to advancing the dataloader iterator step by step. When `True`,
+            this fast-forward is skipped to save time, but may affect
+            reproducibility if the dataloader has state-dependent behavior.
     """
 
     def __init__(self,
@@ -289,8 +358,7 @@ class IterBasedTrainLoop(BaseLoop):
                     'that has already been trained',
                     logger='current',
                     level=logging.INFO)
-                for _ in range(self._iter):
-                    next(self.dataloader_iterator)
+                self.dataloader_iterator.skip_iter(self._iter)
             else:
                 print_log(
                     'Skip advancing dataloader to save time. Note that this '

--- a/tests/test_dataset/test_sampler.py
+++ b/tests/test_dataset/test_sampler.py
@@ -195,5 +195,5 @@ class TestInfiniteSampler(TestCase):
 
     def test_skip_negative(self):
         sampler = InfiniteSampler(self.dataset)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             sampler.skip(-1)

--- a/tests/test_dataset/test_sampler.py
+++ b/tests/test_dataset/test_sampler.py
@@ -139,3 +139,61 @@ class TestInfiniteSampler(TestCase):
     def test_set_epoch(self):
         sampler = InfiniteSampler(self.dataset)
         sampler.set_epoch(10)
+
+    @patch('mmengine.dataset.sampler.get_dist_info', return_value=(0, 1))
+    def test_skip(self, mock):
+        # skip should land on the same deterministic position as an
+        # uninterrupted run, generating indices only (no data loading).
+        skip = 30
+        tail = 20
+
+        full = InfiniteSampler(self.dataset, shuffle=True, seed=42)
+        full_iter = iter(full)
+        expected = [next(full_iter) for _ in range(skip + tail)][skip:]
+
+        resumed = InfiniteSampler(self.dataset, shuffle=True, seed=42)
+        resumed.skip(skip)
+        resumed_iter = iter(resumed)
+        actual = [next(resumed_iter) for _ in range(tail)]
+
+        self.assertEqual(actual, expected)
+
+    @patch('mmengine.dataset.sampler.get_dist_info', return_value=(2, 3))
+    def test_skip_dist(self, mock):
+        # skip must respect the per-rank slicing.
+        skip = 15
+        tail = 10
+
+        full = InfiniteSampler(self.dataset, shuffle=False)
+        full_iter = iter(full)
+        expected = [next(full_iter) for _ in range(skip + tail)][skip:]
+
+        resumed = InfiniteSampler(self.dataset, shuffle=False)
+        resumed.skip(skip)
+        resumed_iter = iter(resumed)
+        actual = [next(resumed_iter) for _ in range(tail)]
+
+        self.assertEqual(actual, expected)
+
+    @patch('mmengine.dataset.sampler.get_dist_info', return_value=(1, 4))
+    def test_skip_dist_shuffle(self, mock):
+        # Highest-risk case: shuffle=True with rank slicing and a skip that
+        # crosses several `randperm` epochs of the underlying stream.
+        skip = self.data_length * 3 + 7
+        tail = 12
+
+        full = InfiniteSampler(self.dataset, shuffle=True, seed=123)
+        full_iter = iter(full)
+        expected = [next(full_iter) for _ in range(skip + tail)][skip:]
+
+        resumed = InfiniteSampler(self.dataset, shuffle=True, seed=123)
+        resumed.skip(skip)
+        resumed_iter = iter(resumed)
+        actual = [next(resumed_iter) for _ in range(tail)]
+
+        self.assertEqual(actual, expected)
+
+    def test_skip_negative(self):
+        sampler = InfiniteSampler(self.dataset)
+        with self.assertRaises(AssertionError):
+            sampler.skip(-1)

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -14,7 +14,7 @@ import torch
 import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel
 from torch.optim import SGD, Adam
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import BatchSampler, DataLoader, Dataset
 
 from mmengine.config import Config
 from mmengine.dataset import DefaultSampler, pseudo_collate
@@ -2730,6 +2730,35 @@ class TestRunner(TestCase):
         batch = next(dataloader_iterator)
         self.assertEqual(batch.tolist(), expected)
         self.assertEqual(dataset.fetch_count, batch_size)
+
+    def test_resume_skip_iter_with_batch_sampler(self):
+        # Explicit batch_sampler makes DataLoader expose a default sampler at
+        # ``dataloader.sampler``. The fast path should unwrap PyTorch's standard
+        # BatchSampler and use its underlying InfiniteSampler instead.
+        from mmengine.dataset import InfiniteSampler
+
+        batch_size = 2
+        skip_iters = 4
+        skipped = skip_iters * batch_size
+
+        dataset = IndexDataset()
+        sampler = InfiniteSampler(dataset, shuffle=True, seed=42)
+        batch_sampler = BatchSampler(
+            sampler, batch_size=batch_size, drop_last=False)
+        dataloader = DataLoader(
+            dataset, batch_sampler=batch_sampler, num_workers=0)
+        dataloader_iterator = _InfiniteDataloaderIterator(dataloader)
+
+        dataloader_iterator.skip_iter(skip_iters)
+        self.assertIsNone(dataloader_iterator._iterator)
+
+        expected_sampler = InfiniteSampler(dataset, shuffle=True, seed=42)
+        expected_iter = iter(expected_sampler)
+        expected = [next(expected_iter)
+                    for _ in range(skipped + batch_size)][skipped:]
+
+        batch = next(dataloader_iterator)
+        self.assertEqual(batch.tolist(), expected)
 
     def test_resume_skip_iter_lazy_iterator(self):
         # White-box guard for the lazy-iterator contract: the underlying

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -210,6 +210,18 @@ class ToyDatasetNoMeta(Dataset):
         return dict(inputs=self.data[index], data_sample=self.label[index])
 
 
+class IndexDataset(Dataset):
+    # Returns the requested index so resume position can be asserted from the
+    # batch contents. Defined at module level to be picklable for DataLoader
+    # worker processes.
+
+    def __len__(self):
+        return 20
+
+    def __getitem__(self, index):
+        return index
+
+
 class ToyMetric1(BaseMetric):
 
     def __init__(self, collect_device='cpu', dummy_metrics=None):
@@ -2578,8 +2590,30 @@ class TestRunner(TestCase):
         self.assertIsNone(runner.param_schedulers)
 
         # 2.8 test fast_forward_on_resume parameter in IterBasedTrainLoop
+        class CountingDataset(Dataset):
+
+            def __init__(self):
+                self.fetch_count = 0
+
+            def __len__(self):
+                return 12
+
+            def __getitem__(self, index):
+                self.fetch_count += 1
+                return index
+
+        dataset = CountingDataset()
+        dataloader_iterator = _InfiniteDataloaderIterator(
+            DataLoader(dataset, batch_size=1, num_workers=0))
+        dataloader_iterator.skip_iter(3)
+        self.assertEqual(dataset.fetch_count, 0)
+        data = next(dataloader_iterator)
+        self.assertEqual(data.item(), 3)
+        self.assertEqual(dataset.fetch_count, 1)
+
         # 2.8.1 test fast_forward_on_resume=False (default behavior)
-        # When False, the dataloader should iterate through skipped steps
+        # When False, the dataloader should advance skipped indices without
+        # loading skipped batches.
         cfg = copy.deepcopy(self.iter_based_cfg)
         cfg.experiment_name = 'test_checkpoint20'
         cfg.train_cfg = dict(
@@ -2590,16 +2624,22 @@ class TestRunner(TestCase):
         runner = Runner.from_cfg(cfg)
         runner.train()
 
-        # Track dataloader iterator calls during resume
         dataloader_next_count = []
+        skip_iters = []
 
         original_next = _InfiniteDataloaderIterator.__next__
+        original_skip_iter = _InfiniteDataloaderIterator.skip_iter
 
         def tracked_next(self):
             dataloader_next_count.append(1)
             return original_next(self)
 
+        def tracked_skip_iter(self, num_iters):
+            skip_iters.append(num_iters)
+            return original_skip_iter(self, num_iters)
+
         _InfiniteDataloaderIterator.__next__ = tracked_next
+        _InfiniteDataloaderIterator.skip_iter = tracked_skip_iter
 
         try:
             # Resume from iter 6 checkpoint
@@ -2613,21 +2653,17 @@ class TestRunner(TestCase):
                 fast_forward_on_resume=False)
             runner = Runner.from_cfg(cfg)
 
-            # Clear counter before resume
             dataloader_next_count.clear()
+            skip_iters.clear()
             runner.resume(path)
-
-            # With fast_forward_on_resume=False, the iterator should be
-            # advanced 6 times during resume (for already trained iters)
-            # plus 6 times during the remaining training
             runner.train()
 
-            # Total should be: 6 (fast-forward) + 6 (remaining training) = 12
-            self.assertEqual(len(dataloader_next_count), 12)
+            self.assertEqual(skip_iters, [6])
+            self.assertEqual(len(dataloader_next_count), 6)
             self.assertEqual(runner.iter, 12)
 
             # 2.8.2 test fast_forward_on_resume=True
-            # When True, the fast-forward loop should be skipped
+            # When True, the fast-forward loop should be skipped.
             path = osp.join(self.temp_dir, 'iter_6.pth')
             cfg = copy.deepcopy(self.iter_based_cfg)
             cfg.experiment_name = 'test_checkpoint22'
@@ -2638,21 +2674,113 @@ class TestRunner(TestCase):
                 fast_forward_on_resume=True)
             runner = Runner.from_cfg(cfg)
 
-            # Clear counter before resume
             dataloader_next_count.clear()
+            skip_iters.clear()
             runner.resume(path)
-
-            # With fast_forward_on_resume=True, the iterator should NOT be
-            # advanced during resume, only during the remaining training
             runner.train()
 
-            # Total should be: 0 (no fast-forward) + 6 (remaining training) = 6
+            self.assertEqual(skip_iters, [])
             self.assertEqual(len(dataloader_next_count), 6)
             self.assertEqual(runner.iter, 12)
 
         finally:
             # Restore original method
             _InfiniteDataloaderIterator.__next__ = original_next
+            _InfiniteDataloaderIterator.skip_iter = original_skip_iter
+
+    def test_resume_skip_iter_with_infinite_sampler(self):
+        # With an InfiniteSampler, skip_iter should advance at the sampler
+        # level: no data is loaded for skipped iters, and iteration resumes at
+        # the deterministic position. The mechanism is num_workers-agnostic
+        # because the skip happens on the main-process sampler stream.
+        from mmengine.dataset import InfiniteSampler
+
+        class CountingDataset(Dataset):
+
+            def __init__(self):
+                self.fetch_count = 0
+
+            def __len__(self):
+                return 20
+
+            def __getitem__(self, index):
+                self.fetch_count += 1
+                return index
+
+        batch_size = 2
+        skip_iters = 4
+        skipped = skip_iters * batch_size
+
+        dataset = CountingDataset()
+        sampler = InfiniteSampler(dataset, shuffle=True, seed=42)
+        dataloader = DataLoader(
+            dataset, batch_size=batch_size, sampler=sampler, num_workers=0)
+        dataloader_iterator = _InfiniteDataloaderIterator(dataloader)
+
+        dataloader_iterator.skip_iter(skip_iters)
+        # Skipping must not trigger any data loading.
+        self.assertEqual(dataset.fetch_count, 0)
+
+        # The resumed batch must match the deterministic stream position.
+        expected_sampler = InfiniteSampler(dataset, shuffle=True, seed=42)
+        expected_iter = iter(expected_sampler)
+        expected = [next(expected_iter)
+                    for _ in range(skipped + batch_size)][skipped:]
+
+        batch = next(dataloader_iterator)
+        self.assertEqual(batch.tolist(), expected)
+        self.assertEqual(dataset.fetch_count, batch_size)
+
+    def test_resume_skip_iter_lazy_iterator(self):
+        # White-box guard for the lazy-iterator contract: the underlying
+        # dataloader iterator must not be created until the first ``__next__``,
+        # so that ``skip_iter`` can fast-forward the sampler *before* any worker
+        # is spawned. Eager creation would make ``num_workers > 0`` prefetch and
+        # discard the skipped data.
+        from mmengine.dataset import InfiniteSampler
+
+        dataset = IndexDataset()
+        sampler = InfiniteSampler(dataset, shuffle=True, seed=42)
+        dataloader = DataLoader(
+            dataset, batch_size=2, sampler=sampler, num_workers=0)
+        dataloader_iterator = _InfiniteDataloaderIterator(dataloader)
+
+        # Not created on construction ...
+        self.assertIsNone(dataloader_iterator._iterator)
+        # ... nor by the sampler-level fast path ...
+        dataloader_iterator.skip_iter(3)
+        self.assertIsNone(dataloader_iterator._iterator)
+        # ... only on the first actual fetch.
+        next(dataloader_iterator)
+        self.assertIsNotNone(dataloader_iterator._iterator)
+
+    def test_resume_skip_iter_multi_worker(self):
+        # End-to-end proof that sampler-level skip is correct with real worker
+        # processes (``num_workers=2``): the first resumed batch must equal the
+        # deterministic stream position. Workers are only spawned on the first
+        # fetch, i.e. after the skip, so they prefetch from the resumed position
+        # rather than from index 0.
+        from mmengine.dataset import InfiniteSampler
+
+        batch_size = 2
+        skip_iters = 3
+        skipped = skip_iters * batch_size
+
+        dataset = IndexDataset()
+        sampler = InfiniteSampler(dataset, shuffle=True, seed=42)
+        dataloader = DataLoader(
+            dataset, batch_size=batch_size, sampler=sampler, num_workers=2)
+        dataloader_iterator = _InfiniteDataloaderIterator(dataloader)
+
+        dataloader_iterator.skip_iter(skip_iters)
+
+        expected_sampler = InfiniteSampler(dataset, shuffle=True, seed=42)
+        expected_iter = iter(expected_sampler)
+        expected = [next(expected_iter)
+                    for _ in range(skipped + batch_size)][skipped:]
+
+        batch = next(dataloader_iterator)
+        self.assertEqual(batch.tolist(), expected)
 
     def test_build_runner(self):
         # No need to test other cases which have been tested in


### PR DESCRIPTION
<!-- Suggested PR title: perf(runner): speed up --resume by fast-forwarding the sampler instead of reloading data -->

## Motivation

Resuming an iteration-based run (`IterBasedTrainLoop`) is currently slow. To restore the exact training position after a checkpoint, the loop advances the dataloader one step at a time through every already-trained iteration. On the default path this re-reads and discards all skipped samples, and with `num_workers > 0` it additionally spawns workers that prefetch data which is immediately thrown away. For long runs (hundreds of thousands of iterations) this is pure overhead and can add a large delay before training continues.

This problem and its intended solution are tracked upstream in OpenMMLab:

- **[open-mmlab/mmengine#1520](https://github.com/open-mmlab/mmengine/issues/1520)** — *[Feature] Speed up the resume process of the IterBased loop*: the original feature request. It describes the exact problem (advancing the dataloader executes real data loading/preprocessing and is slow) and explicitly notes that naively iterating the `batch_sampler` to skip works with `num_workers = 0` but **corrupts the data order with multiple workers**.
- **[open-mmlab/mmengine#1548](https://github.com/open-mmlab/mmengine/pull/1548)** — *Speed up `--resume`*: proposes skipping via the private `_iterator._next_index()`.
- **[open-mmlab/mmengine#1608](https://github.com/open-mmlab/mmengine/pull/1608)** — *[Fix] Fix IterBased Loop Training with Faster Resume*: proposes skipping via `itertools.islice` on the dataloader iterator.

Both proposed fixes act on the **dataloader iterator** and are not safe with `num_workers > 0` — the multi-worker ordering problem the feature request above calls out. [#1548](https://github.com/open-mmlab/mmengine/pull/1548) advances the sampler via the private `_next_index()`, which only works for a single-process iterator (with workers it desyncs the prefetch state); [#1608](https://github.com/open-mmlab/mmengine/pull/1608) advances the already-built iterator after the workers are spawned (so the skipped data is still loaded), and as written its `islice` result is never consumed.

This repository already shipped a partial mitigation upstream:

- **[VBTI-development/onedl-mmengine#27](https://github.com/VBTI-development/onedl-mmengine/pull/27)** — added the `fast_forward_on_resume` flag, which lets users skip the fast-forward entirely. That avoids the cost but sacrifices state consistency / reproducibility, because the dataloader is no longer positioned where the interrupted run left off.

The goal of this PR is to make the fast-forward itself cheap, so resuming is fast **and** lands on the exact same deterministic position as an uninterrupted run — without forcing users to trade away reproducibility. Unlike the iterator-level fixes above, it skips at the **sampler level in the main process, before any worker is spawned**, so it is correct and loads no data for any `num_workers`. This resolves the feature request in [#1520](https://github.com/open-mmlab/mmengine/issues/1520) — including the multi-worker ordering pitfall it explicitly calls out — while keeping a graceful fallback for samplers that cannot skip.

## Modification

**Fast path** (used automatically when the sampler supports it):

- **`InfiniteSampler.skip(num_samples)`** (`mmengine/dataset/sampler.py`): fast-forwards the deterministic, per-rank index stream by `num_samples` using `itertools.islice`. It only *generates* indices (no data is loaded) and is `num_workers`-agnostic, because the skip happens on the main-process sampler stream before any worker is created.
- **`_InfiniteDataloaderIterator`** (`mmengine/runner/loops.py`):
  - The underlying dataloader iterator is now created **lazily** (on first `__next__`). This is essential: it lets `skip_iter` fast-forward the sampler *before* any worker is spawned, so `num_workers > 0` no longer prefetches and discards the skipped data.
  - `skip_iter` resolves the batch size (including the custom `batch_sampler` case), converts the resumed iteration count into a number of sampler indices, calls `sampler.skip(...)`, and drops the iterator so it is rebuilt at the resumed position.

**Fallback path** (same behavior as before, now explicit):

- When the sampler has no `skip` method or the batch size cannot be resolved (e.g. a custom `batch_sampler`), the loop falls back to advancing the iterator step by step and emits an explicit `WARNING` explaining that the fast path is unavailable and that, with `num_workers > 0`, the skipped data is still loaded and discarded.

**Docs & tests:**

- Updated the `fast_forward_on_resume` docstring to describe the new sampler-level fast-forward and the fallback.
- Added `InfiniteSampler.skip` tests: single-rank, distributed slicing, shuffle across multiple `randperm` epochs, and a negative-input guard.
- Added runner tests: a white-box test proving the iterator is built lazily, and an end-to-end **`num_workers=2`** test proving the first resumed batch matches the deterministic stream position.

## BC-breaking (Optional)

No. Public APIs are unchanged. `InfiniteSampler.skip` is a new, additive method. `_InfiniteDataloaderIterator` is internal and its observable iteration behavior is unchanged (the iterator is simply created on first use). The default resume behavior yields the same indices as before, only faster.

## Use cases (Optional)

Resuming `IterBasedTrainLoop` with an `InfiniteSampler` (the recommended sampler for iteration-based training) is now fast by default:

- `num_workers = 0`: skipped iterations advance the sampler without loading data.
- `num_workers > 0`: workers are spawned only after the skip, so they prefetch from the resumed position instead of from index 0.

No configuration change is required to benefit. Users who previously set `fast_forward_on_resume=True` purely to avoid the slow fast-forward can now leave it at the default `False` and keep reproducibility.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. (flake8 / isort / yapf / mypy / docformatter all pass)
- [x] The modification is covered by complete unit tests, including a real `num_workers=2` case.
- [ ] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
- [x] The documentation has been modified accordingly (docstrings updated).
