### PR TITLE
fix(packaging): include mmengine/dist in release artifacts

### DIFF
--- a/.github/scripts/verify-package-contents.py
+++ b/.github/scripts/verify-package-contents.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import tarfile
+import zipfile
+from pathlib import Path
+
+EXPECTED_FILES = {
+    'mmengine/dist/__init__.py',
+    'mmengine/dist/dist.py',
+    'mmengine/dist/utils.py',
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('dist_dir', nargs='?', default='dist')
+    return parser.parse_args()
+
+
+def require_one(paths: list[Path], pattern: str) -> Path:
+    if len(paths) != 1:
+        raise SystemExit(
+            f'Expected exactly one {pattern} artifact, found {len(paths)}')
+    return paths[0]
+
+
+def verify_wheel(wheel: Path) -> None:
+    with zipfile.ZipFile(wheel) as zf:
+        names = set(zf.namelist())
+
+    missing = EXPECTED_FILES - names
+    if missing:
+        raise SystemExit(f'{wheel.name} missing {sorted(missing)}')
+
+
+def verify_sdist(sdist: Path) -> None:
+    with tarfile.open(sdist) as tf:
+        names = set(tf.getnames())
+
+    prefix = sdist.name.removesuffix('.tar.gz')
+    missing = {
+        name
+        for name in EXPECTED_FILES
+        if f'{prefix}/{name}' not in names
+    }
+    if missing:
+        raise SystemExit(f'{sdist.name} missing {sorted(missing)}')
+
+
+def main() -> None:
+    args = parse_args()
+    dist_dir = Path(args.dist_dir)
+    wheel = require_one(sorted(dist_dir.glob('onedl_mmengine-*.whl')), 'wheel')
+    sdist = require_one(sorted(dist_dir.glob('onedl_mmengine-*.tar.gz')), 'sdist')
+    verify_wheel(wheel)
+    verify_sdist(sdist)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/verify-package-contents.py
+++ b/.github/scripts/verify-package-contents.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 import argparse
 import tarfile
 import zipfile
@@ -41,8 +40,7 @@ def verify_sdist(sdist: Path) -> None:
     prefix = sdist.name.removesuffix('.tar.gz')
     missing = {
         name
-        for name in EXPECTED_FILES
-        if f'{prefix}/{name}' not in names
+        for name in EXPECTED_FILES if f'{prefix}/{name}' not in names
     }
     if missing:
         raise SystemExit(f'{sdist.name} missing {sorted(missing)}')
@@ -52,7 +50,8 @@ def main() -> None:
     args = parse_args()
     dist_dir = Path(args.dist_dir)
     wheel = require_one(sorted(dist_dir.glob('onedl_mmengine-*.whl')), 'wheel')
-    sdist = require_one(sorted(dist_dir.glob('onedl_mmengine-*.tar.gz')), 'sdist')
+    sdist = require_one(
+        sorted(dist_dir.glob('onedl_mmengine-*.tar.gz')), 'sdist')
     verify_wheel(wheel)
     verify_sdist(sdist)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
         run: uv build --no-sources --sdist --wheel --out-dir dist
       - name: Check distributions
         run: uvx twine check dist/*
+      - name: Verify package contents
+        run: python .github/scripts/verify-package-contents.py dist
       - name: Verify wheel install
         run: >-
           uv run --isolated --no-project --python 3.10

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,7 +24,9 @@ jobs:
           python-version: '3.10'
       - name: Build MMEngine
         run: |
-          uv build --sdist
+          uv build --sdist --wheel
+      - name: Verify package contents
+        run: python .github/scripts/verify-package-contents.py dist
       - name: Publish distribution to PyPI
         run: |
           uv publish

--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,4 @@ work_dirs/
 .dist_test/
 temp_dir/
 dvc.yaml
-dist/
+/dist/


### PR DESCRIPTION
## Summary

- Anchor the root build artifact ignore rule from `dist/` to `/dist/` so Hatchling no longer excludes the runtime package `mmengine/dist`.
- Add `.github/scripts/verify-package-contents.py` to verify both wheel and sdist include the expected `mmengine/dist` files.
- Update CI and deploy workflows to run the shared package content verification before artifacts are uploaded or published.
- Update deploy to build both sdist and wheel before publishing.

## Background

After the migration to Hatchling, release artifacts could miss the `mmengine/dist` package because Hatchling respects `.gitignore`. The unanchored `dist/` ignore pattern matches nested directories named `dist`, including `mmengine/dist`, even though it is runtime package code rather than a build output directory.

## Test plan

- [x] `uv build --no-sources --sdist --wheel --out-dir dist`
- [x] `python .github/scripts/verify-package-contents.py dist`
- [x] `uv run --isolated --no-project --python 3.10 --with "$(ls dist/onedl_mmengine-*.whl)" python -c "import importlib.metadata as m; import mmengine; assert m.version('onedl-mmengine') == mmengine.__version__; print(mmengine.__version__)"`